### PR TITLE
95: tooltip message disabled inside accordion

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,4 +1,8 @@
 export default function decorate(block) {
+  const allAnchorTags = document.querySelectorAll('a');
+  allAnchorTags.forEach((anchorTag) => {
+    anchorTag.removeAttribute('title');
+  });
   const divCta = document.querySelector('div .cta');
   block.classList.add('faq-accordion');
   if (divCta) {


### PR DESCRIPTION
Tooltip message disabled inside accordion:

Fix #95 

Test URLs:
- Before: https://main--aldevron--hlxsites.hlx.page/
- After: https://accordion--aldevron--hlxsites.hlx.page/test/accordion-cta
