### PR TITLE
Block for audio embed

### DIFF
--- a/blocks/audio-embed/audio-embed.js
+++ b/blocks/audio-embed/audio-embed.js
@@ -1,0 +1,17 @@
+function extractContainerId(url) {
+  const urlObj = new URL(url);
+  const params = new URLSearchParams(urlObj.search);
+  return params.get('container_id');
+}
+
+export default function decorate(block) {
+  const anchorLink = block.querySelector('a').href;
+  const containerId = extractContainerId(anchorLink);
+  const divElement = document.createElement('div');
+  divElement.setAttribute('id', containerId);
+  const scriptTag = document.createElement('script');
+  scriptTag.src = anchorLink;
+  divElement.appendChild(scriptTag);
+  block.innerHTML = '';
+  block.append(divElement);
+}


### PR DESCRIPTION
Block for audio embed from buzzsprout.com

Fix #138 

Test URLs:
- Before: https://main--aldevron--hlxsites.hlx.page/
- After: https://feature-audio-embed--aldevron--hlxsites.hlx.page/test/audio-embed
