### PR TITLE
284 Adding classes to capture the large hero background colours

### DIFF
--- a/styles/Typo.css
+++ b/styles/Typo.css
@@ -1603,6 +1603,10 @@ form.hs-form .hs-input[type="checkbox"] {
     background-color: #e47031;
 }
 
+.hero.large.background-yellow{
+    background-color: #ec8f2d;
+}
+
 .hero.large.background-green{
     background-color: #78a12e;
 }
@@ -1613,6 +1617,14 @@ form.hs-form .hs-input[type="checkbox"] {
 
 .hero.large.background-blue{
     background-color: #005796;
+}
+
+.hero.large.background-black{
+    background-color: #0d233e;
+}
+
+.hero.large.background-purple{
+    background-color: #6f2a8e;
 }
 
 .hero.large > div:nth-child(1) picture > img {

--- a/styles/Typo.css
+++ b/styles/Typo.css
@@ -1599,6 +1599,22 @@ form.hs-form .hs-input[type="checkbox"] {
     background-color: #ededed;
 }
 
+.hero.large.background-orange{
+    background-color: #e47031;
+}
+
+.hero.large.background-green{
+    background-color: #78a12e;
+}
+
+.hero.large.background-red{
+    background-color: #d1222b;
+}
+
+.hero.large.background-blue{
+    background-color: #005796;
+}
+
 .hero.large > div:nth-child(1) picture > img {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #284 

Test URLs:
- Before: https://main--aldevron--hlxsites.hlx.page
- After: https://284-colour-hero-banner--aldevron--hlxsites.hlx.live/
- After https://284-colour-hero-banner--aldevron--hlxsites.hlx.live/25th-anniversary/a-paradigm-shift-for-mrna
