### PR TITLE
293 GTM Hostname

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -38,7 +38,7 @@ function loadGTM() {
 
 if (
   !window.location.hostname.includes('localhost')
-    && !document.location.hostname.includes('.hlx.page')
+    && !document.location.hostname.includes('.hlx')
 ) {
   loadGTM();
 }


### PR DESCRIPTION
Updating to include both the live and page Helix sites

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aldevron--hlxsites.hlx.page
- After: https://293-gtm-hostname--aldevron--hlxsites.hlx.live/
