### PR TITLE
Utm flow setup

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -246,7 +246,7 @@ function loadDelayed() {
 
 
 /*
-To Continue Smoother flow of UTMs
+To Continue Smoother flow of UTMs across the pages user visits in same session.
 */
 
 // check if UTM parameters exist in the URL
@@ -282,7 +282,7 @@ function getUTMParameters() {
     utm_medium: utmMedium,
     utm_campaign: utmCampaign,
     utm_term: utmTerm,
-    utm_content: utmContent
+    utm_content: utmContent,
   };
 
   return utmData;
@@ -309,8 +309,6 @@ function getUTMDataFromLocalStorage() {
   const utmDataString = sessionStorage.getItem('utm_data');
   if (utmDataString) {
     return JSON.parse(utmDataString);
-  } else {
-    return null;
   }
 }
 
@@ -329,19 +327,16 @@ function addUTMParametersToURL() {
   }
 }
 
-function correctUTMFlow(){
+function correctUTMFlow() {
   if (checkUTMParametersExist()) {
-    console.log('UTM parameters exist in the URL.');
-    // Call the function to store UTM parameters when the page loads
+    /* console.log('UTM parameters exist in the URL.');
+    Call the function to store UTM parameters when the page loads */
     storeUTMParameters();
-
-  } else if(checkUTMParametersInLocalStorage()){
-    console.log('UTM parameters do not exist in the URL but present in Local storage');
+  } else if (checkUTMParametersInLocalStorage()) {
+    // console.log('UTM parameters do not exist in the URL but present in Local storage');
     addUTMParametersToURL();
-
-  }else{
-    console.log('No UTMs No Worry!');
-    
+  } else {
+    //console.log('No UTMs Found!');
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -244,7 +244,6 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
-
 /*
 To Continue Smoother flow of UTMs across the pages user visits in same session.
 */
@@ -293,7 +292,7 @@ function storeUTMParameters() {
   const utmData = getUTMParameters();
 
   // Check if UTM parameters exist
-  if (Object.values(utmData).some(param => param !== null && param !== undefined)) {
+  if (Object.values(utmData).some(param => (param !== null && param !== undefined))) {
     // Convert the object to a JSON string and store it in local storage
     sessionStorage.setItem('utm_data', JSON.stringify(utmData));
   }
@@ -309,6 +308,8 @@ function getUTMDataFromLocalStorage() {
   const utmDataString = sessionStorage.getItem('utm_data');
   if (utmDataString) {
     return JSON.parse(utmDataString);
+  } else {
+    return null;
   }
 }
 
@@ -336,7 +337,7 @@ function correctUTMFlow() {
     // console.log('UTM parameters do not exist in the URL but present in Local storage');
     addUTMParametersToURL();
   } else {
-    //console.log('No UTMs Found!');
+    // console.log('No UTMs Found!');
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -329,22 +329,27 @@ function addUTMParametersToURL() {
   }
 }
 
-// Example usage:
-if (checkUTMParametersExist()) {
-  console.log('UTM parameters exist in the URL.');
-  // Call the function to store UTM parameters when the page loads
-  storeUTMParameters();
+function correctUTMFlow(){
+  if (checkUTMParametersExist()) {
+    console.log('UTM parameters exist in the URL.');
+    // Call the function to store UTM parameters when the page loads
+    storeUTMParameters();
 
-} else if(checkUTMParametersInLocalStorage()){
-  console.log('UTM parameters do not exist in the URL but present in Local storage');
-  addUTMParametersToURL();
+  } else if(checkUTMParametersInLocalStorage()){
+    console.log('UTM parameters do not exist in the URL but present in Local storage');
+    addUTMParametersToURL();
 
+  }else{
+    console.log('No UTMs No Worry!');
+    
+  }
 }
 
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();
+  correctUTMFlow();
 }
 
 loadPage();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -260,9 +260,8 @@ function checkUTMParametersExist() {
   // Check if any of the UTM parameters exist
   if (utmSource || utmMedium || utmCampaign || utmTerm || utmContent) {
     return true; // UTM parameters exist
-  } else {
-    return false; // UTM parameters do not exist
   }
+  return false; // UTM parameters do not exist
 }
 
 // Get UTM parameters from the URL
@@ -292,7 +291,7 @@ function storeUTMParameters() {
   const utmData = getUTMParameters();
 
   // Check if UTM parameters exist
-  if (Object.values(utmData).some(param => (param !== null && param !== undefined))) {
+  if (Object.values(utmData).some((param) => param !== null && param !== undefined)) {
     // Convert the object to a JSON string and store it in local storage
     sessionStorage.setItem('utm_data', JSON.stringify(utmData));
   }
@@ -308,9 +307,8 @@ function getUTMDataFromLocalStorage() {
   const utmDataString = sessionStorage.getItem('utm_data');
   if (utmDataString) {
     return JSON.parse(utmDataString);
-  } else {
-    return null;
   }
+  return null;
 }
 
 // To add UTM parameters to the browser's URL
@@ -318,7 +316,7 @@ function addUTMParametersToURL() {
   const utmData = getUTMDataFromLocalStorage();
   if (utmData) {
     const urlParams = new URLSearchParams(window.location.search);
-    Object.keys(utmData).forEach(key => {
+    Object.keys(utmData).forEach((key) => {
       if (!urlParams.has(key) && utmData[key]) {
         urlParams.append(key, utmData[key]);
       }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -244,6 +244,103 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
+
+/*
+To Continue Smoother flow of UTMs
+*/
+
+// check if UTM parameters exist in the URL
+function checkUTMParametersExist() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const utmSource = urlParams.get('utm_source');
+  const utmMedium = urlParams.get('utm_medium');
+  const utmCampaign = urlParams.get('utm_campaign');
+  const utmTerm = urlParams.get('utm_term');
+  const utmContent = urlParams.get('utm_content');
+
+  // Check if any of the UTM parameters exist
+  if (utmSource || utmMedium || utmCampaign || utmTerm || utmContent) {
+    return true; // UTM parameters exist
+  } else {
+    return false; // UTM parameters do not exist
+  }
+}
+
+// Get UTM parameters from the URL
+function getUTMParameters() {
+  const urlParams = new URLSearchParams(window.location.search);
+  // Define UTM parameter names
+  const utmSource = urlParams.get('utm_source');
+  const utmMedium = urlParams.get('utm_medium');
+  const utmCampaign = urlParams.get('utm_campaign');
+  const utmTerm = urlParams.get('utm_term');
+  const utmContent = urlParams.get('utm_content');
+
+  // Create an object to store UTM parameters
+  const utmData = {
+    utm_source: utmSource,
+    utm_medium: utmMedium,
+    utm_campaign: utmCampaign,
+    utm_term: utmTerm,
+    utm_content: utmContent
+  };
+
+  return utmData;
+}
+
+// To store UTM parameters in local storage
+function storeUTMParameters() {
+  const utmData = getUTMParameters();
+
+  // Check if UTM parameters exist
+  if (Object.values(utmData).some(param => param !== null && param !== undefined)) {
+    // Convert the object to a JSON string and store it in local storage
+    sessionStorage.setItem('utm_data', JSON.stringify(utmData));
+  }
+}
+
+function checkUTMParametersInLocalStorage() {
+  const utmDataString = sessionStorage.getItem('utm_data');
+  return utmDataString !== null && utmDataString !== undefined;
+}
+
+// Retrive UTM parameters from storage.
+function getUTMDataFromLocalStorage() {
+  const utmDataString = sessionStorage.getItem('utm_data');
+  if (utmDataString) {
+    return JSON.parse(utmDataString);
+  } else {
+    return null;
+  }
+}
+
+// To add UTM parameters to the browser's URL
+function addUTMParametersToURL() {
+  const utmData = getUTMDataFromLocalStorage();
+  if (utmData) {
+    const urlParams = new URLSearchParams(window.location.search);
+    Object.keys(utmData).forEach(key => {
+      if (!urlParams.has(key) && utmData[key]) {
+        urlParams.append(key, utmData[key]);
+      }
+    });
+    const newURL = window.location.origin + window.location.pathname + '?' + urlParams.toString();
+    window.history.replaceState({}, document.title, newURL);
+  }
+}
+
+// Example usage:
+if (checkUTMParametersExist()) {
+  console.log('UTM parameters exist in the URL.');
+  // Call the function to store UTM parameters when the page loads
+  storeUTMParameters();
+
+} else if(checkUTMParametersInLocalStorage()){
+  console.log('UTM parameters do not exist in the URL but present in Local storage');
+  addUTMParametersToURL();
+
+}
+
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -321,7 +321,7 @@ function addUTMParametersToURL() {
         urlParams.append(key, utmData[key]);
       }
     });
-    const newURL = `${window.location.origin}${window.location.pathname}?${urlParams.toString()}`
+    const newURL = `${window.location.origin}${window.location.pathname}?${urlParams.toString()}`;
     window.history.replaceState({}, document.title, newURL);
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -321,7 +321,7 @@ function addUTMParametersToURL() {
         urlParams.append(key, utmData[key]);
       }
     });
-    const newURL = window.location.origin + window.location.pathname + '?' + urlParams.toString();
+    const newURL = `${window.location.origin}${window.location.pathname}?${urlParams.toString()}`
     window.history.replaceState({}, document.title, newURL);
   }
 }


### PR DESCRIPTION
**Issue:**
Currently when user goes from one page to another, the initial UTM parameters are getting removed due to URL change/redirect.

**Example:** User came to Home page [https://www.aldevron.com?utm_source=UTM-test&utm_medium=website&utm_campaign=script-test-by-developer](https://www.aldevron.com/?utm_source=UTM-test&utm_medium=website&utm_campaign=script-test-by-developer) using this link then he/she clicks on "Contact us" then the page from we get submission is https://www.aldevron.com/about-us/contact-us this only without UTMs so we are not able get the original referance of UTMs from which campaign or asset they converted.

**Work Updates:**
I have cloned main branch and created https://github.com/hlxsites/aldevron/tree/utm-flow-setup this one. Added script to add UTMs if those founds initially.

**Fix: #295**

**Test URL:**
https://utm-flow-setup--aldevron--hlxsites.hlx.page/?utm_source=UTM-test&utm_medium=website&utm_campaign=script-test-by-developer and click on any other page to see the UTMs on that page as well.
